### PR TITLE
Feat/11 resume

### DIFF
--- a/src/domains/resume/resume.controller.ts
+++ b/src/domains/resume/resume.controller.ts
@@ -108,8 +108,8 @@ export class ResumeController {
 
   @Guard('user')
   @Delete()
-  async resetResume(@Body('id') id: string, @DAccount('user') user: User) {
-    await this.resumeService.resetResume(id, user.id);
+  async resetResume(@DAccount('user') user: User) {
+    await this.resumeService.resetResume(user.id);
   }
 
   @Guard('user')

--- a/src/domains/resume/resume.service.ts
+++ b/src/domains/resume/resume.service.ts
@@ -17,6 +17,7 @@ import {
   DSite,
   SortResume,
 } from './resume.dto';
+import { nanoid } from 'nanoid';
 
 @Injectable()
 export class ResumeService {
@@ -95,6 +96,7 @@ export class ResumeService {
   async resetResume(resumeId: string, userId: string) {
     if (resumeId !== userId)
       throw new UnauthorizedException('삭제 권한이 없습니다.');
+
     const target: string[] = [
       'resumeInfo',
       'introduce',
@@ -171,7 +173,7 @@ export class ResumeService {
         return await this.prismaService.introduce.upsert({
           where: { id: value.id || 'undefined' },
           create: {
-            id: 'introduce' + value.index.toString() + userId,
+            id: 'introduce' + userId + '_' + nanoid(4),
             resumeId: userId,
             index: value.index,
             title: value.title,
@@ -200,7 +202,7 @@ export class ResumeService {
         return await this.prismaService.activity.upsert({
           where: { id: value.id || 'undefined' },
           create: {
-            id: 'activity' + value.index.toString() + userId,
+            id: 'activity' + userId + '_' + nanoid(4),
             resumeId: userId,
             index: value.index,
             title: value.title,
@@ -233,7 +235,7 @@ export class ResumeService {
         return await this.prismaService.certificate.upsert({
           where: { id: value.id ?? 'undefined' },
           create: {
-            id: 'certificate' + value.index + userId,
+            id: 'certificate' + userId + '_' + nanoid(4),
             resumeId: userId,
             index: value.index,
             name: value.name,
@@ -268,7 +270,7 @@ export class ResumeService {
         return await this.prismaService.career.upsert({
           where: { id: value.id || 'undefined' },
           create: {
-            id: 'career' + value.index.toString() + userId,
+            id: 'career' + userId + '_' + nanoid(4),
             resumeId: userId,
             index: value.index,
             company: value.company,
@@ -303,7 +305,7 @@ export class ResumeService {
         return await this.prismaService.site.upsert({
           where: { id: value.id || 'undefined' },
           create: {
-            id: 'site' + value.index.toString() + userId,
+            id: 'site' + userId + '_' + nanoid(4),
             resumeId: userId,
             index: value.index,
             title: value.title,
@@ -336,7 +338,7 @@ export class ResumeService {
             id: value.id ?? 'undefined',
           },
           create: {
-            id: 'additionalResume' + value.index.toString() + userId,
+            id: 'additionalResume' + userId + '_' + nanoid(4),
             resumeId: userId,
             index: value.index,
             title: value.title,

--- a/src/domains/resume/resume.service.ts
+++ b/src/domains/resume/resume.service.ts
@@ -3,7 +3,6 @@ import {
   BadRequestException,
   Injectable,
   NotFoundException,
-  UnauthorizedException,
 } from '@nestjs/common';
 import {
   DActivity,
@@ -53,7 +52,7 @@ export class ResumeService {
 
     switch (data.sort) {
       case SortResume.UPDATED_AT:
-        orderByField = { updatedAt: 'asc' };
+        orderByField = { updatedAt: 'desc' };
         break;
       case SortResume.LIKES:
         orderByField = { likes: 'desc' };
@@ -93,10 +92,7 @@ export class ResumeService {
   }
 
   //이력서 초기화
-  async resetResume(resumeId: string, userId: string) {
-    if (resumeId !== userId)
-      throw new UnauthorizedException('삭제 권한이 없습니다.');
-
+  async resetResume(userId: string) {
     const target: string[] = [
       'resumeInfo',
       'introduce',


### PR DESCRIPTION
- 이력서 항목별 아이디 생성 로직 수정
  - 항목분류 + 사용자 아이디 + '_' + nanoid(4)

- 이력서 정렬 방식 수정
  - UPDATED_AT 을 'asc'에서 'desc'로 수정