### PR TITLE
Feat/11 resume

### DIFF
--- a/src/domains/resume/resume.controller.ts
+++ b/src/domains/resume/resume.controller.ts
@@ -98,12 +98,8 @@ export class ResumeController {
 
   @Guard('user')
   @Delete('item')
-  async deleteItem(
-    @Param('item') item: string,
-    @Body('id') id: string,
-    @DAccount('user') user: User,
-  ) {
-    await this.resumeService.deleteItem(item, user.id);
+  async deleteItem(@Body('id') id: string, @DAccount('user') user: User) {
+    await this.resumeService.deleteItem(id, user.id);
   }
 
   @Guard('user')

--- a/src/domains/resume/resume.controller.ts
+++ b/src/domains/resume/resume.controller.ts
@@ -97,8 +97,8 @@ export class ResumeController {
   }
 
   @Guard('user')
-  @Delete('item')
-  async deleteItem(@Body('id') id: string, @DAccount('user') user: User) {
+  @Delete(':id')
+  async deleteItem(@Param('id') id: string, @DAccount('user') user: User) {
     await this.resumeService.deleteItem(id, user.id);
   }
 

--- a/src/domains/resume/resume.dto.ts
+++ b/src/domains/resume/resume.dto.ts
@@ -2,9 +2,9 @@ import { ExposeRange } from '@prisma/client';
 import { IsEnum } from 'class-validator';
 
 export enum SortResume {
-  'UPDATED_AT',
-  'PROPOSAL',
-  'LIKES',
+  UPDATED_AT = 'UPDATED_AT',
+  PROPOSAL = 'PROPOSAL',
+  LIKES = 'LIKES',
 }
 
 export class DResume {

--- a/src/domains/resume/resume.service.ts
+++ b/src/domains/resume/resume.service.ts
@@ -4,6 +4,7 @@ import {
   BadRequestException,
   Injectable,
   NotFoundException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import {
   DActivity,
@@ -18,7 +19,6 @@ import {
   SortResume,
 } from './resume.dto';
 import { nanoid } from 'nanoid';
-import { User } from '../user/user.dto';
 
 @Injectable()
 export class ResumeService {

--- a/src/domains/resume/resume.service.ts
+++ b/src/domains/resume/resume.service.ts
@@ -90,7 +90,7 @@ export class ResumeService {
         where: { id: itemId, resumeId: userId },
       });
     } catch {
-      throw new NotFoundException('존재하지 않는 항목입니다.');
+      throw new NotFoundException('권한이 없거나 존재하지 않는 항목입니다.');
     }
   }
 

--- a/src/domains/resume/resume.service.ts
+++ b/src/domains/resume/resume.service.ts
@@ -48,17 +48,18 @@ export class ResumeService {
 
   //다수 이력서 조회
   async getAllResumes(data: DGetAllResumes) {
-    let orderByField: object;
+    const orderByField: object[] = [];
 
     switch (data.sort) {
       case SortResume.UPDATED_AT:
-        orderByField = { updatedAt: 'desc' };
+        orderByField.push({ updatedAt: 'desc' });
         break;
       case SortResume.LIKES:
-        orderByField = { likes: 'desc' };
+        orderByField.push({ likes: 'desc' }, { updatedAt: 'desc' });
         break;
-      default:
-        orderByField = { proposal: 'desc' };
+      case SortResume.PROPOSAL:
+        orderByField.push({ proposal: 'desc' }, { updatedAt: 'desc' });
+        break;
     }
 
     const resumes = await this.prismaService.resume.findMany({

--- a/src/domains/resume/resume.service.ts
+++ b/src/domains/resume/resume.service.ts
@@ -90,7 +90,7 @@ export class ResumeService {
         where: { id: itemId, resumeId: userId },
       });
     } catch {
-      throw new NotFoundException('권한이 없거나 존재하지 않는 항목입니다.');
+      throw new BadRequestException('권한이 없거나 존재하지 않는 항목입니다.');
     }
   }
 


### PR DESCRIPTION
- 다수 이력서 조회하는 경우, 이력서 정렬 로직 수정
  - 조건별 정렬 후 (좋아요 순, 면접 제안 순)
  - 업데이트 최신순으로 정렬

- 이력서 초기화 로직 수정
  - 좋아요 내역 전체 삭제 (추후 수정 필요할 수 있음)
  - 이력서 정보 및 개인정보 기본값으로 변경
  - 이력서 항목 전체 삭제

- 이력서 개별 항목 삭제 로직 수정
  - 예외처리 상세하게 변경 (404에서 401을 고려하여 404로 수정)
  - 경로 /resume/:id로 수정